### PR TITLE
Fix reverse connectivity

### DIFF
--- a/Examples/parastell_example.py
+++ b/Examples/parastell_example.py
@@ -69,3 +69,8 @@ for surf in stellarator.invessel_build.dag_model.surfaces:
 print(stellarator.invessel_build.dag_model.volumes)
 
 print(stellarator.invessel_build.dag_model.groups)
+
+stellarator.construct_magnets(
+    "../tests/files_for_tests/coils.example", 10, 10, 90
+)
+stellarator.export_magnets()

--- a/parastell/invessel_build.py
+++ b/parastell/invessel_build.py
@@ -22,7 +22,7 @@ from .utils import (
 )
 
 
-def create_moab_tris_from_verts(corners, mbc):
+def create_moab_tris_from_verts(corners, mbc, reverse=False):
     """Create 2 moab triangle elements from a list of 4 pymoab verts.
 
     Arguments:
@@ -33,13 +33,20 @@ def create_moab_tris_from_verts(corners, mbc):
     Returns:
         list of two pymoab MBTRI elements
     """
-
-    tri_1 = mbc.create_element(
-        types.MBTRI, [corners[2], corners[1], corners[0]]
-    )
-    tri_2 = mbc.create_element(
-        types.MBTRI, [corners[3], corners[2], corners[0]]
-    )
+    if reverse:
+        tri_1 = mbc.create_element(
+            types.MBTRI, [corners[0], corners[1], corners[2]]
+        )
+        tri_2 = mbc.create_element(
+            types.MBTRI, [corners[0], corners[2], corners[3]]
+        )
+    else:
+        tri_1 = mbc.create_element(
+            types.MBTRI, [corners[2], corners[1], corners[0]]
+        )
+        tri_2 = mbc.create_element(
+            types.MBTRI, [corners[3], corners[2], corners[0]]
+        )
 
     return [tri_1, tri_2]
 
@@ -388,12 +395,9 @@ class InVesselBuild(object):
             corner3 = rib2.mb_verts[rib_loci_index + 1]
             corner4 = rib2.mb_verts[rib_loci_index]
             corners = [corner1, corner2, corner3, corner4]
-            if reverse:
-                mb_tris += create_moab_tris_from_verts(
-                    corners[-1::-1], self.mbc
-                )
-            else:
-                mb_tris += create_moab_tris_from_verts(corners, self.mbc)
+            mb_tris += create_moab_tris_from_verts(
+                corners, self.mbc, reverse=reverse
+            )
         return mb_tris
 
     def get_loci(self):
@@ -591,12 +595,9 @@ class Surface(object):
                 corner3 = next_rib.mb_verts[rib_pt_index + 1]
                 corner4 = next_rib.mb_verts[rib_pt_index]
                 corners = [corner1, corner2, corner3, corner4]
-                if reverse:
-                    mb_tris += create_moab_tris_from_verts(
-                        corners[-1::-1], mbc
-                    )
-                else:
-                    mb_tris += create_moab_tris_from_verts(corners, mbc)
+                mb_tris += create_moab_tris_from_verts(
+                    corners, mbc, reverse=reverse
+                )
         surface = dagmc.Surface.create(dag_model)
         mbc.add_entities(surface.handle, mb_tris)
 


### PR DESCRIPTION
Previously the list of corners was simply reverse to change the handedness of the tris. This resulted in in a mismatch between the orientation of the triangles in the innermost surface and the subsequent surface, due to the need to have the normals point toward in the implicit complement.